### PR TITLE
fix qt in macox env ctrl and control together

### DIFF
--- a/src/libs/katevi/src/command.cpp
+++ b/src/libs/katevi/src/command.cpp
@@ -28,6 +28,11 @@ using namespace KateVi;
 Command::Command(NormalViMode *parent, QString pattern,
                  bool(NormalViMode::*commandMethod)(), unsigned int flags)
 {
+    //Judge the OS CTRL, CTRL replaced with META because QT.
+#if defined(Q_OS_MACOS) || defined(Q_OS_MAC)
+    pattern.replace(QLatin1String("c-"), "m-");
+#endif
+
     m_parent = parent;
     m_pattern = KeyParser::self()->encodeKeySequence(pattern);
     m_flags = flags;

--- a/src/libs/katevi/src/command.cpp
+++ b/src/libs/katevi/src/command.cpp
@@ -30,7 +30,7 @@ Command::Command(NormalViMode *parent, QString pattern,
 {
     //Judge the OS CTRL, CTRL replaced with META because QT.
 #if defined(Q_OS_MACOS) || defined(Q_OS_MAC)
-    pattern.replace(QLatin1String("c-"), "m-");
+    pattern.replace(QLatin1String("c-"), QLatin1String("m-"));
 #endif
 
     m_parent = parent;

--- a/src/libs/katevi/src/modes/insertvimode.cpp
+++ b/src/libs/katevi/src/modes/insertvimode.cpp
@@ -295,7 +295,7 @@ bool InsertViMode::commandSwitchToNormalModeForJustOneCommand()
 bool InsertViMode::handleKeyPress(const QKeyEvent *e)
 {
     // backspace should work even if the shift key is down
-    if (ViUtils::isControlModifier(e->modifiers()) && e->key() == Qt::Key_Backspace) {
+    if (!ViUtils::isControlModifier(e->modifiers()) && e->key() == Qt::Key_Backspace) {
         m_interface->backspace();
         return true;
     }

--- a/src/libs/katevi/src/modes/insertvimode.cpp
+++ b/src/libs/katevi/src/modes/insertvimode.cpp
@@ -295,7 +295,7 @@ bool InsertViMode::commandSwitchToNormalModeForJustOneCommand()
 bool InsertViMode::handleKeyPress(const QKeyEvent *e)
 {
     // backspace should work even if the shift key is down
-    if (e->modifiers() != Qt::ControlModifier && e->key() == Qt::Key_Backspace) {
+    if (ViUtils::isControlModifier(e->modifiers()) && e->key() == Qt::Key_Backspace) {
         m_interface->backspace();
         return true;
     }
@@ -360,7 +360,7 @@ bool InsertViMode::handleKeyPress(const QKeyEvent *e)
             default:
                 return false;
             }
-        } else if (e->modifiers() == Qt::ControlModifier) {
+        } else if (ViUtils::isControlModifier(e->modifiers())) {
             switch (e->key()) {
             case Qt::Key_BracketLeft:
                 leaveInsertMode();

--- a/src/libs/katevi/src/modes/normalvimode.cpp
+++ b/src/libs/katevi/src/modes/normalvimode.cpp
@@ -115,9 +115,10 @@ bool NormalViMode::handleKeyPress(const QKeyEvent *e)
     clearYankHighlight();
 
     auto adapter = m_viInputModeManager->inputAdapter();
+    // Back normal mode, distinguish between OS CTRL.
     if (keyCode == Qt::Key_Escape
-        || (keyCode == Qt::Key_C && modifiers == Qt::ControlModifier)
-        || (keyCode == Qt::Key_BracketLeft && modifiers == Qt::ControlModifier)) {
+        || (keyCode == Qt::Key_C && ViUtils::isControlModifier(modifiers))
+        || (keyCode == Qt::Key_BracketLeft && ViUtils::isControlModifier(modifiers))) {
         adapter->setCaretStyle(KateViI::Block);
         m_pendingResetIsDueToExit = true;
         // Vim in weird as if we e.g. i<ctrl-o><ctrl-c> it claims (in the status bar) to

--- a/src/libs/katevi/src/modes/replacevimode.cpp
+++ b/src/libs/katevi/src/modes/replacevimode.cpp
@@ -100,7 +100,7 @@ bool ReplaceViMode::commandMoveOneWordRight()
 bool ReplaceViMode::handleKeyPress(const QKeyEvent *e)
 {
     // backspace should work even if the shift key is down
-    if (ViUtils::isControlModifier(e->modifiers()) && e->key() == Qt::Key_Backspace) {
+    if (!ViUtils::isControlModifier(e->modifiers()) && e->key() == Qt::Key_Backspace) {
         backspace();
         return true;
     }

--- a/src/libs/katevi/src/modes/replacevimode.cpp
+++ b/src/libs/katevi/src/modes/replacevimode.cpp
@@ -23,6 +23,7 @@
 #include <katevi/inputmodemanager.h>
 #include <katevi/interface/katevieditorinterface.h>
 #include <katevi/interface/kateviconfig.h>
+#include <viutils.h>
 #include <marks.h>
 
 using namespace KateVi;
@@ -99,7 +100,7 @@ bool ReplaceViMode::commandMoveOneWordRight()
 bool ReplaceViMode::handleKeyPress(const QKeyEvent *e)
 {
     // backspace should work even if the shift key is down
-    if (e->modifiers() != Qt::ControlModifier && e->key() == Qt::Key_Backspace) {
+    if (ViUtils::isControlModifier(e->modifiers()) && e->key() == Qt::Key_Backspace) {
         backspace();
         return true;
     }
@@ -143,7 +144,7 @@ bool ReplaceViMode::handleKeyPress(const QKeyEvent *e)
         default:
             return false;
         }
-    } else if (e->modifiers() == Qt::ControlModifier) {
+    } else if (ViUtils::isControlModifier(e->modifiers())) {
         switch (e->key()) {
         case Qt::Key_BracketLeft:
         case Qt::Key_C:

--- a/src/libs/katevi/src/viutils.cpp
+++ b/src/libs/katevi/src/viutils.cpp
@@ -22,3 +22,13 @@ bool ViUtils::isRegister(QChar p_char)
            || p_char == QLatin1Char('#')
            || p_char == QLatin1Char('^');
 }
+
+// Just judge MacOS for now, everything else is considered to be same.
+bool ViUtils::isControlModifier(int p_modifiers)
+{
+#if defined(Q_OS_MACOS) || defined(Q_OS_MAC)
+    return p_modifiers == Qt::MetaModifier;
+#else
+    return p_modifiers == Qt::ControlModifier;
+#endif
+}

--- a/src/libs/katevi/src/viutils.h
+++ b/src/libs/katevi/src/viutils.h
@@ -14,7 +14,7 @@ namespace KateVi
 
         static bool isRegister(QChar p_char);
 
-        // Judge the OS CTRL
+        // Judge the OS CTRL.
         static bool isControlModifier(int p_modifiers);
     };
 }

--- a/src/libs/katevi/src/viutils.h
+++ b/src/libs/katevi/src/viutils.h
@@ -13,6 +13,9 @@ namespace KateVi
         static bool isModifier(int p_keyCode);
 
         static bool isRegister(QChar p_char);
+
+        // Judge the OS CTRL
+        static bool isControlModifier(int p_modifiers);
     };
 }
 


### PR DESCRIPTION
Because of the default setting of Qt.

The `CTRL` and `Control` in the MacOS environment are mixed.It's all mixed up in `Command`.

Repair logic was added to break it apart, following the habit of using Vim in MacOS.

